### PR TITLE
OTP27 support - allow_entities

### DIFF
--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -272,7 +272,8 @@ defmodule Samly.IdpData do
       space: :normalize,
       namespace_conformant: true,
       comments: false,
-      default_attrs: true
+      default_attrs: true,
+      allow_entities: true
     ]
 
     md_xml = SweetXml.parse(metadata_xml, xml_opts)


### PR DESCRIPTION
A change in xmerl defaults released in OTP 27, and made in https://github.com/erlang/otp/issues/7539 (c.f. [detailed release notes](https://erlang.org/download/otp_src_27.0.readme))

Some default values in Xmerl has been changed to avoid XML External Entity
(XXE) vulnerabilities if you're parsing untrusted XML.
xmerl_scan: the default value for allow_entities has changed to false.
xmerl_sax_parser: the default value for external_entities has changed to none.

Own Id: OTP-19079
Application(s): xmerl
Related Id(s): GH-7539

XXE was not discovered in OTP26 so it's safe to use these entities for OTP27